### PR TITLE
fix: sched_setscheduler() gets EINVAL for normal policies

### DIFF
--- a/config/src/scheduler/mod.rs
+++ b/config/src/scheduler/mod.rs
@@ -180,6 +180,14 @@ impl FromStr for SchedPolicy {
     }
 }
 
+impl SchedPolicy {
+    /// Whether the policy is realtime (FIFO or RR)
+    #[must_use]
+    pub fn is_realtime(self) -> bool {
+        matches!(self, Self::Fifo | Self::Rr)
+    }
+}
+
 /// A value between 1 and 99
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SchedPriority(u8);

--- a/daemon/src/priority.rs
+++ b/daemon/src/priority.rs
@@ -45,7 +45,13 @@ pub fn set(buffer: &mut Buffer, process: u32, profile: &Profile) {
 
 pub fn set_policy(pid: u32, policy: SchedPolicy, sched_priority: SchedPriority) {
     let param = libc::sched_param {
-        sched_priority: libc::c_int::from(sched_priority.get()),
+        sched_priority: libc::c_int::from({
+            if policy.is_realtime() {
+                sched_priority.get()
+            } else {
+                0
+            }
+        }),
     };
 
     unsafe {


### PR DESCRIPTION
In sched_setscheduler(2):
For each of the above policies (other batch rr),
param->sched_priority must be 0.
However, currently SchedPriority is set to 1 by default, which causes sched_setscheduler() gets EINVAL errno.