### PR TITLE
add nix-daemon

### DIFF
--- a/data/rhel.kdl
+++ b/data/rhel.kdl
@@ -69,6 +69,7 @@ assignments {
 		nix
 		nix-env
 		nix-channel
+		nix-daemon
 		ostree
 		packagekitd
 		pacman


### PR DESCRIPTION
Give the same priority to nix-daemon as the other parts of the nix package manager.